### PR TITLE
1.0.5

### DIFF
--- a/docs/FortinetFortimanagerJsonRpcConnectorDoc.md
+++ b/docs/FortinetFortimanagerJsonRpcConnectorDoc.md
@@ -4,7 +4,7 @@ The Fortinet FortiManager JSON RPC Connector is an advanced connector with freef
 
 ### Version information
 
-Connector Version: 1.0.4
+Connector Version: 1.0.5
 
 Authored By: Fortinet CSE
 
@@ -12,8 +12,8 @@ Contributors: Dylan Spille
 
 Certified: No
 
-## Release Notes for version 1.0.4
-Following enhancements have been made to the Fortinet FortiManager JSON RPC Connector in version 1.0.4:
+## Release Notes for version 1.0.5
+Following enhancements have been made to the Fortinet FortiManager JSON RPC Connector in version 1.0.5:
 
 <ul>
 <li>Added support to specify a task timeout on the execute action.</li>
@@ -117,7 +117,7 @@ The following automated operations can be included in playbooks and you can also
 
  The output contains a non-dictionary value.
 ## Included playbooks
-The `Sample - fortinet-fortimanager-json-rpc - 1.0.4` playbook collection comes bundled with the Fortinet FortiManager JSON RPC connector. These playbooks contain steps using which you can perform all supported actions. You can see bundled playbooks in the **Automation** > **Playbooks** section in FortiSOAR&trade; after importing the Fortinet FortiManager JSON RPC connector.
+The `Sample - fortinet-fortimanager-json-rpc - 1.0.5` playbook collection comes bundled with the Fortinet FortiManager JSON RPC connector. These playbooks contain steps using which you can perform all supported actions. You can see bundled playbooks in the **Automation** > **Playbooks** section in FortiSOAR&trade; after importing the Fortinet FortiManager JSON RPC connector.
 
 - JSON RPC Add
 - JSON RPC Delete

--- a/fortinet-fortimanager-json-rpc/generic_json_rpc.py
+++ b/fortinet-fortimanager-json-rpc/generic_json_rpc.py
@@ -165,7 +165,8 @@ def perform_rpc_action(action: str, config: dict, params: dict) -> dict:
 
             response[f"{action}_response"] = action_response
             # If the action is execute and track_task is set to True, track the task
-            if action == 'execute' and params.get("track_task", False):
+            # Also need to make sure that the response is a dict because some exec actions like sys/proxy/info can return a list
+            if action == 'execute' and params.get("track_task", False) and isinstance(action_response, dict):
                 task = action_response.get('task') or action_response.get('taskid')
                 task_timeout = parse_task_timeout(params.get("task_timeout"))
                 status, task_response = fmg.track_task(task, timeout=task_timeout)

--- a/fortinet-fortimanager-json-rpc/generic_json_rpc.py
+++ b/fortinet-fortimanager-json-rpc/generic_json_rpc.py
@@ -134,7 +134,10 @@ def perform_rpc_action(action: str, config: dict, params: dict) -> dict:
             url = params.get("url")
             # To handle locking ADOM's when freeform action is used, I will pick the first url found and lock that adom.
             if action == "free_form":
-                url = data.get("data", [])[0].get("url", url)
+                # make sure data is a list before accessing the first instance
+                if not isinstance(data.get("data", None), list):
+                    raise ConnectorError("Payload must be a list")
+                url = data["data"][0].get("url", url)
             adom = parse_adom_from_input(url, data)
             response = {}
 

--- a/fortinet-fortimanager-json-rpc/generic_json_rpc.py
+++ b/fortinet-fortimanager-json-rpc/generic_json_rpc.py
@@ -48,6 +48,22 @@ def parse_data(data: Union[list, bool, str, dict]):
     return data
 
 
+def parse_task_timeout(task_timeout, default=120):
+    """
+    Function to parse task_timeout from params.
+
+    :param task_timeout: task_timeout from params
+    :param default: Default timeout value if parsing fails.
+    :return: Parsed integer timeout value.
+    """
+    task_timeout = task_timeout or default
+    try:
+        task_timeout = int(task_timeout)
+    except ValueError:
+        task_timeout = default
+    return task_timeout
+
+
 def parse_adom_from_input(url: str, data: Union[list, dict]) -> str:
     match = re.search(r'/adom/([^/]+)/', url)
     if match:
@@ -148,7 +164,7 @@ def perform_rpc_action(action: str, config: dict, params: dict) -> dict:
             # If the action is execute and track_task is set to True, track the task
             if action == 'execute' and params.get("track_task", False):
                 task = action_response.get('task') or action_response.get('taskid')
-                task_timeout = int(params.get("task_timeout", 120)) or 120
+                task_timeout = parse_task_timeout(params.get("task_timeout"))
                 status, task_response = fmg.track_task(task, timeout=task_timeout)
                 response["task_response"] = task_response
                 # I'm not sure if we need to commit changes here after the task is tracked, but leaving it here for now

--- a/fortinet-fortimanager-json-rpc/info.json
+++ b/fortinet-fortimanager-json-rpc/info.json
@@ -1,13 +1,13 @@
 {
   "name": "fortinet-fortimanager-json-rpc",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "label": "Fortinet FortiManager JSON RPC",
   "description": "The Fortinet FortiManager JSON RPC Connector is an advanced connector with freeform actions to use the JSON-RPC API directly. This connector puts the onus on the user to understand the FortiManager API. To use the connector that simplify actions please see the original Fortinet FortiManager Connector",
   "publisher": "Fortinet CSE",
   "cs_approved": false,
   "cs_compatible": true,
   "category": "Centralized Security Management",
-  "help_online": "https://github.com/fortinet-fortisoar/connector-fortinet-fortimanager-json-rpc/blob/release/1.0.4/docs/FortinetFortimanagerJsonRpcConnectorDoc.md",
+  "help_online": "https://github.com/fortinet-fortisoar/connector-fortinet-fortimanager-json-rpc/blob/release/1.0.5/docs/FortinetFortimanagerJsonRpcConnectorDoc.md",
   "icon_small_name": "FortiManager_small.png",
   "icon_large_name": "FortiManager_medium.png",
   "configuration": {
@@ -315,7 +315,7 @@
             "delete",
             "replace",
             "clone",
-            "execute",
+            "exec",
             "move",
             "unset"
           ]

--- a/fortinet-fortimanager-json-rpc/playbooks/playbooks.json
+++ b/fortinet-fortimanager-json-rpc/playbooks/playbooks.json
@@ -4,7 +4,7 @@
     {
       "uuid": "c11d3444-7674-4d31-ba69-eae27af4c7f6",
       "@type": "WorkflowCollection",
-      "name": "Sample - Fortinet FortiManager JSON RPC - 1.0.4",
+      "name": "Sample - Fortinet FortiManager JSON RPC - 1.0.5",
       "description": "The Fortinet FortiManager JSON RPC Connector is an advanced connector with freeform actions to use the JSON-RPC API directly. This connector puts the onus on the user to understand the FortiManager API. To use the connector that simplify actions please see the original Fortinet FortiManager Connector",
       "visible": true,
       "image": null,
@@ -68,7 +68,7 @@
                 "name": "Fortinet FortiManager JSON RPC",
                 "config": "''",
                 "params": [],
-                "version": "1.0.4",
+                "version": "1.0.5",
                 "connector": "fortinet-fortimanager-json-rpc",
                 "operation": "json_rpc_add",
                 "operationTitle": "JSON RPC Add"
@@ -145,7 +145,7 @@
                 "name": "Fortinet FortiManager JSON RPC",
                 "config": "''",
                 "params": [],
-                "version": "1.0.4",
+                "version": "1.0.5",
                 "connector": "fortinet-fortimanager-json-rpc",
                 "operation": "json_rpc_set",
                 "operationTitle": "JSON RPC Set"
@@ -225,7 +225,7 @@
                   "url": "/dvmdb/device",
                   "data": ""
                 },
-                "version": "1.0.4",
+                "version": "1.0.5",
                 "connector": "fortinet-fortimanager-json-rpc",
                 "operation": "json_rpc_get",
                 "operationTitle": "JSON RPC Get"
@@ -304,7 +304,7 @@
                 "params": {
                   "track_task": false
                 },
-                "version": "1.0.4",
+                "version": "1.0.5",
                 "connector": "fortinet-fortimanager-json-rpc",
                 "operation": "json_rpc_execute",
                 "operationTitle": "JSON RPC Exec"
@@ -381,7 +381,7 @@
                 "name": "Fortinet FortiManager JSON RPC",
                 "config": "''",
                 "params": [],
-                "version": "1.0.4",
+                "version": "1.0.5",
                 "connector": "fortinet-fortimanager-json-rpc",
                 "operation": "json_rpc_delete",
                 "operationTitle": "JSON RPC Delete"
@@ -458,7 +458,7 @@
                 "name": "Fortinet FortiManager JSON RPC",
                 "config": "''",
                 "params": [],
-                "version": "1.0.4",
+                "version": "1.0.5",
                 "connector": "fortinet-fortimanager-json-rpc",
                 "operation": "json_rpc_freeform",
                 "operationTitle": "JSON RPC Freeform"

--- a/fortinet-fortimanager-json-rpc/release_notes.md
+++ b/fortinet-fortimanager-json-rpc/release_notes.md
@@ -1,8 +1,7 @@
 #### What's Improved
 
-Following enhancements have been made to the Fortinet FortiManager JSON RPC Connector in version 1.0.4: 
+Following enhancements have been made to the Fortinet FortiManager JSON RPC Connector in version 1.0.5: 
 
-* Added support to specify a task timeout on the execute action.
-* Fixed issue with the freeform action.
-* Added testing framework for all actions.
-
+* Fixed small bug with freeform action with the execute method selected
+* Fixed small bug with algorithm to parse the adom from the playbook parameters which resulted in the incorrect adom being locked for workspace mode scenarios
+* Enhanced logging for workspace locking scenarios

--- a/tests/sequential/test_sequential_fortimanager_rpc.py
+++ b/tests/sequential/test_sequential_fortimanager_rpc.py
@@ -32,8 +32,10 @@ operations = operations_package.operations
 # import the generic_json_rpc module
 generic_json_rpc_module_name = "fortinet-fortimanager-json-rpc.generic_json_rpc"
 generic_json_rpc_package = importlib.import_module(generic_json_rpc_module_name)
+
 # import the generic_json_rpc functions
 parse_adom_from_input = generic_json_rpc_package.parse_adom_from_input
+parse_task_timeout = generic_json_rpc_package.parse_task_timeout
 parse_data = generic_json_rpc_package.parse_data
 
 config = {
@@ -192,6 +194,34 @@ def test_adom_and_data_parse_functions():
         acquired_adom = parse_adom_from_input(url, data)
         assert acquired_adom == correct_adom, f"Expected adom {correct_adom} but got {acquired_adom}"
 
+
+def test_parse_task_timeout():
+    payload = [
+        {
+            "task_timeout": '',
+            "expected_task_timeout": 120
+        },
+        {
+            "task_timeout": 120,
+            "expected_task_timeout": 120
+        },
+        {
+            "task_timeout": 60,
+            "expected_task_timeout": 60
+        },
+        {
+            "expected_task_timeout": 120
+        },
+        {
+            "task_timeout": None,
+            "expected_task_timeout": 120
+        }
+    ]
+    for test in payload:
+        task_timeout = test.get("task_timeout")
+        expected_task_timeout = test.get("expected_task_timeout")
+        task_timeout = parse_task_timeout(task_timeout)
+        assert task_timeout == expected_task_timeout, f"Expected task_timeout {expected_task_timeout} but got {task_timeout}"
 
 # Test the add operation by adding an address object
 def test_rpc_add(setup_params):


### PR DESCRIPTION
Following enhancements have been made to the Fortinet FortiManager JSON RPC Connector in version 1.0.5: 

* Fixed small bug with freeform action with the execute method selected
* Fixed small bug with algorithm to parse the adom from the playbook parameters which resulted in the incorrect adom being locked for workspace mode scenarios
* Fixed small bug with parsing the task timeout integer in scenarios where the playbook step was already created. 
* Enhanced logging for workspace locking scenarios