### PR TITLE
Added JSON RPC Update method

### DIFF
--- a/fortinet-fortimanager-json-rpc/info.json
+++ b/fortinet-fortimanager-json-rpc/info.json
@@ -154,6 +154,39 @@
       "output_schema": {}
     },
     {
+      "operation": "json_rpc_update",
+      "title": "JSON RPC Update",
+      "annotation": "json_rpc_update",
+      "description": "A Generic FMG Update action that lets you specify any valid URL and data object",
+      "category": "investigation",
+      "is_config_required": true,
+      "visible": true,
+      "enabled": true,
+      "parameters": [
+        {
+          "name": "url",
+          "title": "URL",
+          "type": "text",
+          "editable": true,
+          "visible": true,
+          "required": true,
+          "placeholder": "/sys/login/user",
+          "description": "The url you wish to hit"
+        },
+        {
+          "name": "data",
+          "title": "Data",
+          "type": "json",
+          "editable": true,
+          "visible": true,
+          "required": true,
+          "placeholder": {},
+          "description": "Pass a json object for the data you want to send. "
+        }
+      ],
+      "output_schema": {}
+    },
+    {
       "operation": "json_rpc_set",
       "title": "JSON RPC Set",
       "annotation": "json_rpc_set",

--- a/fortinet-fortimanager-json-rpc/operations.py
+++ b/fortinet-fortimanager-json-rpc/operations.py
@@ -29,6 +29,13 @@ def json_rpc_add(config: dict, params: dict) -> dict:
     except Exception as e:
         raise ConnectorError(str(e))
 
+def json_rpc_update(config: dict, params: dict) -> dict:
+    action = "update"
+    try:
+        response = perform_rpc_action(action, config, params)
+        return response
+    except Exception as e:
+        raise ConnectorError(str(e))
 
 def json_rpc_set(config: dict, params: dict) -> dict:
     action = "set"
@@ -77,6 +84,7 @@ def json_rpc_freeform(config: dict, params: dict) -> dict:
 
 operations = {
     'json_rpc_add': json_rpc_add,
+    'json_rpc_update': json_rpc_update,
     'json_rpc_set': json_rpc_set,
     'json_rpc_get': json_rpc_get,
     'json_rpc_execute': json_rpc_execute,

--- a/fortinet-fortimanager-json-rpc/release_notes.md
+++ b/fortinet-fortimanager-json-rpc/release_notes.md
@@ -1,5 +1,9 @@
 #### What's Improved
 
+Following enhancements have been made to the Fortinet FortiManager JSON RPC Connector in version 1.1.1:
+
+- Added JSON RPC Update method
+
 Following enhancements have been made to the Fortinet FortiManager JSON RPC Connector in version 1.1.0: 
 
 - Fixed task tracking issue by implementing an early exit when no task ID is found during execute operations.


### PR DESCRIPTION
This pull request adds support for a new "JSON RPC Update" operation to the Fortinet FortiManager JSON RPC Connector, enabling users to perform generic update actions via RPC. The changes include updates to the operation definitions, backend logic, and documentation.

**New Operation Support:**
* Added a new `json_rpc_update` operation in `info.json`, allowing users to specify any valid URL and data object for generic update actions.
* Implemented the `json_rpc_update` function in `operations.py` to handle the update action using the existing RPC mechanism.
* Registered the new `json_rpc_update` operation in the `operations` dictionary for dispatch.

**Documentation:**
* Updated `release_notes.md` to announce the addition of the JSON RPC Update method in version 1.1.1.